### PR TITLE
Update django migration command

### DIFF
--- a/fabfile/project_conf.py
+++ b/fabfile/project_conf.py
@@ -41,6 +41,9 @@ fabconf['APPS_DIR'] = "/home/%s/webapps" % fabconf['SERVER_USERNAME']
 # Where you want your project installed: /APPS_DIR/PROJECT_NAME
 fabconf['PROJECT_PATH'] = "%s/%s" % (fabconf['APPS_DIR'], fabconf['PROJECT_NAME'])
 
+# Your Django's version "run migrations" command
+fabconf['RUN_MIGRATIONS_CMD'] = "python %s/manage.py syncdb" % fabconf['PROJECT_PATH']
+
 # App domains
 fabconf['DOMAINS'] = "example.com www.example.com"
 

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -131,7 +131,7 @@ configure_instance = [
 
   # Run collectstatic and migrate
   {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py collectstatic -v 0 --noinput"},
-  {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py migrate"},
+  {"action":"virtualenv", "params": "%(RUN_MIGRATIONS_CMD)s"},
 
 
   # Setup supervisor

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -1,4 +1,4 @@
-''' 
+"""
 --------------------------------------------------------------------------------------
 tasks.py
 --------------------------------------------------------------------------------------
@@ -11,23 +11,23 @@ date   : 11 / 3 / 2014
 Tasks include:
     - configure_instance  : Configures a new EC2 instance (as definied in project_conf.py) and return's it's public dns
                             This takes around 8 minutes to complete.
- 
-    - update_packages : Updates the python packages on the server to match those found in requirements/common.txt and 
+
+    - update_packages : Updates the python packages on the server to match those found in requirements/common.txt and
                         requirements/prod.txt
- 
-    - deploy : Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and                   
+
+    - deploy : Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and
                restarts the server
- 
-    - reload_gunicorn : Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you 
+
+    - reload_gunicorn : Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you
                         have made changes to templates/start_gunicorn.bash
- 
-    - reload_nginx : Pushes the nginx config files to the servers and restarts the nginx, use this if you 
+
+    - reload_nginx : Pushes the nginx config files to the servers and restarts the nginx, use this if you
                      have made changes to templates/nginx-app-proxy or templates/nginx.conf
 
-    - reload_supervisor : Pushes the supervisor config files to the servers and restarts the supervisor, use this if you 
+    - reload_supervisor : Pushes the supervisor config files to the servers and restarts the supervisor, use this if you
                           have made changes to templates/supervisord-init or templates/supervisord.conf
 
-'''
+"""
 
 # Spawns a new EC2 instance (as definied in djangofab_conf.py) and return's it's public dns
 # This takes around 8 minutes to complete.
@@ -39,37 +39,37 @@ configure_instance = [
   # sudo apt-get update
   {"action":"sudo", "params":"apt-get update -qq",
     "message":"Updating apt-get"},
-  
+
   # List of APT packages to install
   {"action":"apt",
     "params":["libpq-dev", "nginx", "memcached", "git",
       "python-setuptools", "python-dev", "build-essential", "python-pip"],
     "message":"Installing apt-get packages"},
-  
+
   # List of pypi packages to install
   {"action":"pip", "params":["virtualenv", "virtualenvwrapper","supervisor"],
     "message":"Installing pip packages"},
-  
+
   # Add AWS credentials to the a config file so that boto can access S3
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/boto.cfg",
                                        "destination":"/home/%(SERVER_USERNAME)s/boto.cfg"}},
   {"action":"sudo", "params":"mv /home/%(SERVER_USERNAME)s/boto.cfg /etc/boto.cfg"},
-  
+
   # virtualenvwrapper
   {"action":"sudo", "params":"mkdir %(VIRTUALENV_DIR)s", "message":"Configuring virtualenvwrapper"},
   {"action":"sudo", "params":"chown -R %(SERVER_USERNAME)s: %(VIRTUALENV_DIR)s"},
   {"action":"run", "params":"echo 'export WORKON_HOME=%(VIRTUALENV_DIR)s' >> /home/%(SERVER_USERNAME)s/.profile"},
   {"action":"run", "params":"echo 'source /usr/local/bin/virtualenvwrapper.sh' >> /home/%(SERVER_USERNAME)s/.profile"},
   {"action":"run", "params":"source /home/%(SERVER_USERNAME)s/.profile"},
-  
+
   # webapps alias
   {"action":"run", "params":"""echo "alias webapps='cd %(APPS_DIR)s'" >> /home/%(SERVER_USERNAME)s/.profile""",
     "message":"Creating webapps alias"},
-  
+
   # webapps dir
   {"action":"sudo", "params":"mkdir %(APPS_DIR)s", "message":"Creating webapps directory"},
   {"action":"sudo", "params":"chown -R %(SERVER_USERNAME)s: %(APPS_DIR)s"},
-  
+
   # git setup
   {"action":"run", "params":"git config --global user.name '%(GIT_USERNAME)s'",
     "message":"Configuring git"},
@@ -79,11 +79,11 @@ configure_instance = [
   {"action":"run", "params":"chmod 600 /home/%(SERVER_USERNAME)s/.ssh/%(BITBUCKET_DEPLOY_KEY_NAME)s"},
   {"action":"run", "params":"""echo 'IdentityFile /home/%(SERVER_USERNAME)s/.ssh/%(BITBUCKET_DEPLOY_KEY_NAME)s' >> /home/%(SERVER_USERNAME)s/.ssh/config"""},
   {"action":"run", "params":"ssh-keyscan bitbucket.org >> /home/%(SERVER_USERNAME)s/.ssh/known_hosts"},
-  
+
   # Create virtualevn
   {"action":"run", "params":"mkvirtualenv --no-site-packages %(PROJECT_NAME)s",
     "message":"Creating virtualenv"},
-  
+
   # install django in virtual env
   {"action":"virtualenv", "params":"pip install Django",
     "message":"Installing django"},
@@ -91,24 +91,24 @@ configure_instance = [
   # install psycopg2 drivers for Postgres
   {"action":"virtualenv", "params":"pip install psycopg2",
     "message":"Installing psycopg2"},
-  
+
   # install gunicorn in virtual env
   {"action":"virtualenv", "params":"pip install gunicorn",
     "message":"Installing gunicorn"},
-  
+
   # Clone the git repo
   {"action":"run", "params":"git clone %(BITBUCKET_REPO)s %(PROJECT_PATH)s"},
-  
+
   {"action":"put", "params":{"file":"%(FAB_CONFIG_PATH)s/templates/gunicorn.conf.py",
                             "destination":"%(PROJECT_PATH)s/gunicorn.conf.py"}},
-  
+
   # Create run and log dirs for the gunicorn socket and logs
   {"action":"run", "params":"mkdir %(PROJECT_PATH)s/logs"},
 
   # Add gunicorn startup script to project folder
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/start_gunicorn.bash",
                                        "destination":"%(PROJECT_PATH)s/start_gunicorn.bash"}},
-  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},        
+  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},
 
   # Install the requirements from the pip requirements files
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/common.txt --upgrade"},
@@ -129,9 +129,9 @@ configure_instance = [
   {"action":"sudo", "params":"chown root:root /etc/nginx/sites-available/%(PROJECT_NAME)s"},
   {"action":"sudo", "params":"/etc/init.d/nginx restart", "message":"Restarting nginx"},
 
-  # Run collectstatic and syncdb
+  # Run collectstatic and migrate
   {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py collectstatic -v 0 --noinput"},
-  {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py syncdb"},
+  {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py migrate"},
 
 
   # Setup supervisor
@@ -150,16 +150,16 @@ configure_instance = [
   {"action":"sudo", "params":"update-rc.d supervisord defaults"}
 ]
 
-# Updates the python packages on the server to match those found in requirements/common.txt and 
+# Updates the python packages on the server to match those found in requirements/common.txt and
 # requirements/prod.txt
 update_packages = [
-  
+
   # Updates the python packages
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/common.txt --upgrade"},
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/prod.txt --upgrade"},
 ]
 
-# Pulls the latest commit from the master branch on the server, collects the static files, syncs 
+# Pulls the latest commit from the master branch on the server, collects the static files, syncs
 # the db and restarts the server
 deploy = [
 
@@ -168,26 +168,26 @@ deploy = [
 
   # Update the database
   {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py collectstatic -v 0 --noinput"},
-  {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py syncdb"},
+  {"action":"virtualenv", "params":"python %(PROJECT_PATH)s/manage.py migrate"},
 
   # Restart gunicorn to update the site
   {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}
 ]
 
-# Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this 
+# Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this
 # if you have made changes to templates/start_gunicorn.bash
 reload_gunicorn = [
 
   # Push the gunicorn startup script to server
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/start_gunicorn.bash",
                                        "destination":"%(PROJECT_PATH)s/start_gunicorn.bash"}},
-  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},       
+  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},
 
   # Restart gunicorn to update the site
-  {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}          
+  {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}
 ]
 
-# Pushes the nginx config files to the servers and restarts the nginx, use this if you 
+# Pushes the nginx config files to the servers and restarts the nginx, use this if you
 # have made changes to templates/nginx-app-proxy or templates/nginx.conf
 reload_nginx = [
 
@@ -210,7 +210,7 @@ reload_nginx = [
   {"action":"sudo", "params":"/etc/init.d/nginx restart", "message":"Restarting nginx"},
 ]
 
-# Pushes the supervisor config files to the servers and restarts the supervisor, use this if you 
+# Pushes the supervisor config files to the servers and restarts the supervisor, use this if you
 # have made changes to templates/supervisord-init or templates/supervisord.conf
 reload_supervisor = [
 
@@ -233,6 +233,6 @@ reload_supervisor = [
   {"action":"sudo", "params":"chmod +x /etc/init.d/supervisord"},
   {"action":"sudo", "params":"update-rc.d supervisord defaults"},
 
-  # Restart supervisor 
+  # Restart supervisor
   {"action":"sudo", "params":"supervisorctl start all"}
 ]


### PR DESCRIPTION
Since `django-south` has been merged into Django, the new migration command is `python manage.py migrate`. This PR updates both actions tasks that runs the migration.

But there are projects that still run on older versions of Django, so I think there should be a setting in `project_conf.py` to specify which Django version is being used.
