### PR TITLE
Update fabconf dictionary key names that is related to git.

### DIFF
--- a/fabfile/django_fabric_aws.py
+++ b/fabfile/django_fabric_aws.py
@@ -1,4 +1,4 @@
-''' 
+'''
 --------------------------------------------------------------------------------------
 django_fabric_aws.py
 --------------------------------------------------------------------------------------
@@ -9,30 +9,30 @@ credit : Derived from files in https://github.com/gcollazo/Fabulous
 date   : 11 / 3 / 2014
 
 Commands include:
-    - fab spawn instance  
+    - fab spawn instance
         - Spawns a new EC2 instance (as definied in project_conf.py) and return's it's public dns
           This takes around 8 minutes to complete.
- 
+
     - fab update_packages
-        - Updates the python packages on the server to match those found in requirements/common.txt and 
+        - Updates the python packages on the server to match those found in requirements/common.txt and
           requirements/prod.txt
- 
+
     - fab deploy
-        - Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and                   
+        - Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and
           restarts the server
- 
+
     - fab reload_gunicorn
-        - Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you 
+        - Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you
           have made changes to templates/start_gunicorn.bash
- 
+
     - fab reload_nginx
-        - Pushes the nginx config files to the servers and restarts the nginx, use this if you 
+        - Pushes the nginx config files to the servers and restarts the nginx, use this if you
           have made changes to templates/nginx-app-proxy or templates/nginx.conf
 
     - fab reload_supervisor
-        - Pushes the supervisor config files to the servers and restarts the supervisor, use this if you 
+        - Pushes the supervisor config files to the servers and restarts the supervisor, use this if you
           have made changes to templates/supervisord-init or templates/supervisord.conf
-    
+
     - fab manage:command="management command"
         - Runs a python manage.py command on the server. To run this command we need to specify an argument, eg for syncdb
           type the command -> fab manage:command="syncdb --no-input"
@@ -53,7 +53,7 @@ env.key_filename = fabconf['SSH_PRIVATE_KEY_PATH']
 
 # List of EC2 instances to work on
 env.hosts = fabconf['EC2_INSTANCES']
-         
+
 # ------------------------------------------------------------------------------------------------------------------
 # MAIN FABRIC TASKS - Type fab <function_name> in the command line to execute any one of these
 # ------------------------------------------------------------------------------------------------------------------
@@ -74,7 +74,7 @@ def instance():
     env.host_string = _create_ec2_instance()
     print(_green("Waiting 60 seconds for server to boot..."))
     time.sleep(60)
-    
+
     # Configure the instance that was just created
     for item in tasks.configure_instance:
         try:
@@ -82,7 +82,7 @@ def instance():
         except KeyError:
             pass
         globals()["_" + item['action']](item['params'])
-    
+
     # Print out the final runtime and the public dns of the new instance
     end_time = time.time()
     print(_green("Runtime: %f minutes" % ((end_time - start_time) / 60)))
@@ -94,14 +94,14 @@ def instance():
 
 def deploy():
     """
-    Pulls the latest commit from bitbucket, resyncs the database, collects the static files and restarts the
+    Pulls the latest commit from the remote git repo, resyncs the database, collects the static files and restarts the
     server.
     """
-    _run_task(tasks.deploy, "Updating server to latest commit in the bitbucket repo...", "Finished updating the server")
+    _run_task(tasks.deploy, "Updating server to latest commit in the remote repo...", "Finished updating the server")
 
 def update_packages():
     """
-    Updates the python packages on the server as defined in requirements/common.txt and 
+    Updates the python packages on the server as defined in requirements/common.txt and
     requirements/prod.txt
     """
     _run_task(tasks.update_packages, "Updating server packages with pip...", "Finished updating python packages")
@@ -128,7 +128,7 @@ def manage(command):
     """
     Runs a python manage.py command on the server
     """
-    
+
     # Get the instances to run commands on
     env.hosts = fabconf['EC2_INSTANCES']
 
@@ -183,7 +183,7 @@ def _create_ec2_instance():
 
     instance = reservation.instances[0]
     conn.create_tags([instance.id], {"Name":fabconf['INSTANCE_NAME_TAG']})
-    
+
     while instance.state == u'pending':
         print(_yellow("Instance state: %s" % instance.state))
         time.sleep(10)
@@ -191,7 +191,7 @@ def _create_ec2_instance():
 
     print(_green("Instance state: %s" % instance.state))
     print(_green("Public dns: %s" % instance.public_dns_name))
-    
+
     return instance.public_dns_name
 
 def _virtualenv(params):

--- a/fabfile/project_conf.py
+++ b/fabfile/project_conf.py
@@ -1,4 +1,4 @@
-''' 
+'''
 --------------------------------------------------------------------------------------
 project_conf.py
 --------------------------------------------------------------------------------------
@@ -9,7 +9,7 @@ author : Ashok Fernandez (github.com/ashokfernandez/)
 credit : Derived from files in https://github.com/gcollazo/Fabulous
 date   : 11 / 3 / 2014
 
-Make sure you fill everything out that looks like it needs to be filled out, there are links 
+Make sure you fill everything out that looks like it needs to be filled out, there are links
 in the comments to help.
 '''
 
@@ -23,7 +23,8 @@ fabconf['FAB_CONFIG_PATH'] = os.path.dirname(__file__)
 # Project name
 fabconf['PROJECT_NAME'] = "amazon_app"
 
-# Username for connecting to EC2 instaces - Do not edit unless you have a reason to
+# Username for connecting to EC2 instaces - Do not edit unless you have a
+# reason to
 fabconf['SERVER_USERNAME'] = "ubuntu"
 
 # Full local path for .ssh
@@ -33,13 +34,15 @@ fabconf['SSH_PATH'] = "~/.ssh"
 fabconf['EC2_KEY_NAME'] = "my_ssh_key.pem"
 
 # Don't edit. Full path of the ssh key you use to connect to EC2 instances
-fabconf['SSH_PRIVATE_KEY_PATH'] = '%s/%s' % (fabconf['SSH_PATH'], fabconf['EC2_KEY_NAME'])
+fabconf[
+    'SSH_PRIVATE_KEY_PATH'] = '%s/%s' % (fabconf['SSH_PATH'], fabconf['EC2_KEY_NAME'])
 
 # Where to install apps
 fabconf['APPS_DIR'] = "/home/%s/webapps" % fabconf['SERVER_USERNAME']
 
 # Where you want your project installed: /APPS_DIR/PROJECT_NAME
-fabconf['PROJECT_PATH'] = "%s/%s" % (fabconf['APPS_DIR'], fabconf['PROJECT_NAME'])
+fabconf[
+    'PROJECT_PATH'] = "%s/%s" % (fabconf['APPS_DIR'], fabconf['PROJECT_NAME'])
 
 # App domains
 fabconf['DOMAINS'] = "example.com www.example.com"
@@ -53,21 +56,32 @@ fabconf['ADMIN_EMAIL'] = "admin@example.com"
 # Git username for the server
 fabconf['GIT_USERNAME'] = "EC2"
 
-# Name of the private key file used for github deployments
-fabconf['BITBUCKET_DEPLOY_KEY_NAME'] = "bitbucket_rsa"
+# Name of the private key file used for git deployments
+fabconf['GIT_DEPLOY_KEY_NAME'] = "git_rsa"
 
-# Don't edit. Local path for deployment key you use for github
-fabconf['BITBUCKET_DEPLOY_KEY_PATH'] = "%s/%s" % (fabconf['SSH_PATH'], fabconf['BITBUCKET_DEPLOY_KEY_NAME'])
+# Don't edit. Local path for deployment key you use for git
+fabconf['GIT_DEPLOY_KEY_PATH'] = "%s/%s" % (
+    fabconf['SSH_PATH'], fabconf['GIT_DEPLOY_KEY_NAME'])
 
-# Path to the repo of the application you want to install
-fabconf['BITBUCKET_USERNAME'] = ''
-fabconf['BITBUCKET_REPO_NAME'] = ''
+# The top-level domain name for your remote git service
+fabconf['GIT_HOST_DOMAIN'] = "bitbucket.org"
 
-# Creates the ssh location of your bitbucket repo from the above details
-fabconf['BITBUCKET_REPO'] = "ssh://git@bitbucket.org/%s/%s.git" % (fabconf['BITBUCKET_USERNAME'], fabconf['BITBUCKET_REPO_NAME'])
+# Path to the repo of the application you want to install. The
+# REPO_USERNAME could be same as the GIT_USERNAME if the repo is under the
+# same account else, it is the org username (for orgs) or the username of
+# the projects owner. The REPO_NAME can contain slashes (eg
+# <project_name>/<repo_name> if you are using Bitbucket and the project is
+# within a project)
+fabconf['REPO_USERNAME'] = ''
+fabconf['REPO_NAME'] = ''
+
+# Creates the ssh location of your remote repo from the above details
+fabconf['REPO_URL'] = "ssh://git@%s/%s/%s.git" % (
+    fabconf['GIT_HOST_DOMAIN'], fabconf['REPO_USERNAME'], fabconf['REPO_NAME'])
 
 # Virtualenv activate command
-fabconf['ACTIVATE'] = "source /home/%s/.virtualenvs/%s/bin/activate" % (fabconf['SERVER_USERNAME'], fabconf['PROJECT_NAME'])
+fabconf['ACTIVATE'] = "source /home/%s/.virtualenvs/%s/bin/activate" % (
+    fabconf['SERVER_USERNAME'], fabconf['PROJECT_NAME'])
 
 # Name tag for your server instance on EC2
 fabconf['INSTANCE_NAME_TAG'] = "MyInstance"
@@ -78,7 +92,7 @@ fabconf['AWS_ACCESS_KEY'] = ''
 # EC2 secret. http://bit.ly/j5ImEZ
 fabconf['AWS_SECRET_KEY'] = ''
 
-#EC2 region. http://amzn.to/12jBkm7
+# EC2 region. http://amzn.to/12jBkm7
 ec2_region = 'ap-southeast-2'
 
 # AMI name. http://bit.ly/liLKxj
@@ -93,5 +107,6 @@ ec2_secgroups = ['MySecurityGroup']
 # API Name of instance type. http://bit.ly/mkWvpn
 ec2_instancetype = 't1.micro'
 
-# Existing instances - add the public dns of your instances here when you have spawned them
+# Existing instances - add the public dns of your instances here when you
+# have spawned them
 fabconf['EC2_INSTANCES'] = [""]

--- a/fabfile/tasks.py
+++ b/fabfile/tasks.py
@@ -1,4 +1,4 @@
-''' 
+'''
 --------------------------------------------------------------------------------------
 tasks.py
 --------------------------------------------------------------------------------------
@@ -11,20 +11,20 @@ date   : 11 / 3 / 2014
 Tasks include:
     - configure_instance  : Configures a new EC2 instance (as definied in project_conf.py) and return's it's public dns
                             This takes around 8 minutes to complete.
- 
-    - update_packages : Updates the python packages on the server to match those found in requirements/common.txt and 
+
+    - update_packages : Updates the python packages on the server to match those found in requirements/common.txt and
                         requirements/prod.txt
- 
-    - deploy : Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and                   
+
+    - deploy : Pulls the latest commit from the master branch on the server, collects the static files, syncs the db and
                restarts the server
- 
-    - reload_gunicorn : Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you 
+
+    - reload_gunicorn : Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this if you
                         have made changes to templates/start_gunicorn.bash
- 
-    - reload_nginx : Pushes the nginx config files to the servers and restarts the nginx, use this if you 
+
+    - reload_nginx : Pushes the nginx config files to the servers and restarts the nginx, use this if you
                      have made changes to templates/nginx-app-proxy or templates/nginx.conf
 
-    - reload_supervisor : Pushes the supervisor config files to the servers and restarts the supervisor, use this if you 
+    - reload_supervisor : Pushes the supervisor config files to the servers and restarts the supervisor, use this if you
                           have made changes to templates/supervisord-init or templates/supervisord.conf
 
 '''
@@ -39,51 +39,51 @@ configure_instance = [
   # sudo apt-get update
   {"action":"sudo", "params":"apt-get update -qq",
     "message":"Updating apt-get"},
-  
+
   # List of APT packages to install
   {"action":"apt",
     "params":["libpq-dev", "nginx", "memcached", "git",
       "python-setuptools", "python-dev", "build-essential", "python-pip"],
     "message":"Installing apt-get packages"},
-  
+
   # List of pypi packages to install
   {"action":"pip", "params":["virtualenv", "virtualenvwrapper","supervisor"],
     "message":"Installing pip packages"},
-  
+
   # Add AWS credentials to the a config file so that boto can access S3
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/boto.cfg",
                                        "destination":"/home/%(SERVER_USERNAME)s/boto.cfg"}},
   {"action":"sudo", "params":"mv /home/%(SERVER_USERNAME)s/boto.cfg /etc/boto.cfg"},
-  
+
   # virtualenvwrapper
   {"action":"sudo", "params":"mkdir %(VIRTUALENV_DIR)s", "message":"Configuring virtualenvwrapper"},
   {"action":"sudo", "params":"chown -R %(SERVER_USERNAME)s: %(VIRTUALENV_DIR)s"},
   {"action":"run", "params":"echo 'export WORKON_HOME=%(VIRTUALENV_DIR)s' >> /home/%(SERVER_USERNAME)s/.profile"},
   {"action":"run", "params":"echo 'source /usr/local/bin/virtualenvwrapper.sh' >> /home/%(SERVER_USERNAME)s/.profile"},
   {"action":"run", "params":"source /home/%(SERVER_USERNAME)s/.profile"},
-  
+
   # webapps alias
   {"action":"run", "params":"""echo "alias webapps='cd %(APPS_DIR)s'" >> /home/%(SERVER_USERNAME)s/.profile""",
     "message":"Creating webapps alias"},
-  
+
   # webapps dir
   {"action":"sudo", "params":"mkdir %(APPS_DIR)s", "message":"Creating webapps directory"},
   {"action":"sudo", "params":"chown -R %(SERVER_USERNAME)s: %(APPS_DIR)s"},
-  
+
   # git setup
   {"action":"run", "params":"git config --global user.name '%(GIT_USERNAME)s'",
     "message":"Configuring git"},
   {"action":"run", "params":"git config --global user.email '%(ADMIN_EMAIL)s'"},
-  {"action":"put", "params":{"file":"%(BITBUCKET_DEPLOY_KEY_PATH)s",
-                            "destination":"/home/%(SERVER_USERNAME)s/.ssh/%(BITBUCKET_DEPLOY_KEY_NAME)s"}},
-  {"action":"run", "params":"chmod 600 /home/%(SERVER_USERNAME)s/.ssh/%(BITBUCKET_DEPLOY_KEY_NAME)s"},
-  {"action":"run", "params":"""echo 'IdentityFile /home/%(SERVER_USERNAME)s/.ssh/%(BITBUCKET_DEPLOY_KEY_NAME)s' >> /home/%(SERVER_USERNAME)s/.ssh/config"""},
-  {"action":"run", "params":"ssh-keyscan bitbucket.org >> /home/%(SERVER_USERNAME)s/.ssh/known_hosts"},
-  
+  {"action":"put", "params":{"file":"%(GIT_DEPLOY_KEY_PATH)s",
+                            "destination":"/home/%(SERVER_USERNAME)s/.ssh/%(GIT_DEPLOY_KEY_NAME)s"}},
+  {"action":"run", "params":"chmod 600 /home/%(SERVER_USERNAME)s/.ssh/%(GIT_DEPLOY_KEY_NAME)s"},
+  {"action":"run", "params":"""echo 'IdentityFile /home/%(SERVER_USERNAME)s/.ssh/%(GIT_DEPLOY_KEY_NAME)s' >> /home/%(SERVER_USERNAME)s/.ssh/config"""},
+  {"action":"run", "params":"ssh-keyscan %(GIT_HOST_DOMAIN)s >> /home/%(SERVER_USERNAME)s/.ssh/known_hosts"},
+
   # Create virtualevn
   {"action":"run", "params":"mkvirtualenv --no-site-packages %(PROJECT_NAME)s",
     "message":"Creating virtualenv"},
-  
+
   # install django in virtual env
   {"action":"virtualenv", "params":"pip install Django",
     "message":"Installing django"},
@@ -91,24 +91,24 @@ configure_instance = [
   # install psycopg2 drivers for Postgres
   {"action":"virtualenv", "params":"pip install psycopg2",
     "message":"Installing psycopg2"},
-  
+
   # install gunicorn in virtual env
   {"action":"virtualenv", "params":"pip install gunicorn",
     "message":"Installing gunicorn"},
-  
+
   # Clone the git repo
-  {"action":"run", "params":"git clone %(BITBUCKET_REPO)s %(PROJECT_PATH)s"},
-  
+  {"action":"run", "params":"git clone %(REPO_URL)s %(PROJECT_PATH)s"},
+
   {"action":"put", "params":{"file":"%(FAB_CONFIG_PATH)s/templates/gunicorn.conf.py",
                             "destination":"%(PROJECT_PATH)s/gunicorn.conf.py"}},
-  
+
   # Create run and log dirs for the gunicorn socket and logs
   {"action":"run", "params":"mkdir %(PROJECT_PATH)s/logs"},
 
   # Add gunicorn startup script to project folder
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/start_gunicorn.bash",
                                        "destination":"%(PROJECT_PATH)s/start_gunicorn.bash"}},
-  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},        
+  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},
 
   # Install the requirements from the pip requirements files
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/common.txt --upgrade"},
@@ -150,16 +150,16 @@ configure_instance = [
   {"action":"sudo", "params":"update-rc.d supervisord defaults"}
 ]
 
-# Updates the python packages on the server to match those found in requirements/common.txt and 
+# Updates the python packages on the server to match those found in requirements/common.txt and
 # requirements/prod.txt
 update_packages = [
-  
+
   # Updates the python packages
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/common.txt --upgrade"},
   {"action":"virtualenv", "params":"pip install -r %(PROJECT_PATH)s/requirements/prod.txt --upgrade"},
 ]
 
-# Pulls the latest commit from the master branch on the server, collects the static files, syncs 
+# Pulls the latest commit from the master branch on the server, collects the static files, syncs
 # the db and restarts the server
 deploy = [
 
@@ -174,20 +174,20 @@ deploy = [
   {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}
 ]
 
-# Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this 
+# Pushes the gunicorn startup script to the servers and restarts the gunicorn process, use this
 # if you have made changes to templates/start_gunicorn.bash
 reload_gunicorn = [
 
   # Push the gunicorn startup script to server
   {"action":"put_template", "params":{"template":"%(FAB_CONFIG_PATH)s/templates/start_gunicorn.bash",
                                        "destination":"%(PROJECT_PATH)s/start_gunicorn.bash"}},
-  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},       
+  {"action":"sudo", "params":"chmod +x %(PROJECT_PATH)s/start_gunicorn.bash"},
 
   # Restart gunicorn to update the site
-  {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}          
+  {"action":"sudo", "params": "supervisorctl restart %(PROJECT_NAME)s"}
 ]
 
-# Pushes the nginx config files to the servers and restarts the nginx, use this if you 
+# Pushes the nginx config files to the servers and restarts the nginx, use this if you
 # have made changes to templates/nginx-app-proxy or templates/nginx.conf
 reload_nginx = [
 
@@ -210,7 +210,7 @@ reload_nginx = [
   {"action":"sudo", "params":"/etc/init.d/nginx restart", "message":"Restarting nginx"},
 ]
 
-# Pushes the supervisor config files to the servers and restarts the supervisor, use this if you 
+# Pushes the supervisor config files to the servers and restarts the supervisor, use this if you
 # have made changes to templates/supervisord-init or templates/supervisord.conf
 reload_supervisor = [
 
@@ -233,6 +233,6 @@ reload_supervisor = [
   {"action":"sudo", "params":"chmod +x /etc/init.d/supervisord"},
   {"action":"sudo", "params":"update-rc.d supervisord defaults"},
 
-  # Restart supervisor 
+  # Restart supervisor
   {"action":"sudo", "params":"supervisorctl start all"}
 ]


### PR DESCRIPTION
I update the `fabconf` dictionary keys that related to `git` to universal values. Specifically, the keys updated are:

`BITBUCKET_DEPLOY_KEY_NAME` to `GIT_DEPLOY_KEY_NAME`
`BITBUCKET_DEPLOY_KEY_PATH` to `GIT_DEPLOY_KEY_PATH`
`BITBUCKET_USERNAME` to `REPO_USERNAME` 
`BITBUCKET_REPO_NAME` to `REPO_NAME`
`BITBUCKET_REPO` TO `REPO_URL`

Also, I created a new key `GIT_HOST_DOMAIN` to abstract out the reference to `bitbucket.org` in the conf and tasks module.  I updated the comments to reflect the changes as well.
